### PR TITLE
OpenSuse support + error cecking

### DIFF
--- a/add.sh
+++ b/add.sh
@@ -2,16 +2,34 @@
 
 # This will add the locale en_NL.
 
-# add locale
-cp -f en_NL /usr/share/i18n/locales/
-
-# register locale
-if [ `grep ^en_NL /etc/locale.gen|wc -l` -eq 0 ]; then
-    echo "en_NL.UTF-8 UTF-8" >> /etc/locale.gen
+if [ `id -u` -ne 0 ]; then
+    echo "ERROR: Must be runned as root"
+    exit 1
 fi
 
-# regenerate locales
-locale-gen
+# add locale
+if [ -d /usr/share/i18n/ ]; then
+    cp -f en_NL /usr/share/i18n/locales/
+else
+    echo "ERROR: No /usr/share/i18n/ directory, install glibc-i18ndata"
+    exit 1
+fi
+
+# register locale
+if [ -f /etc/locale.gen ]; then
+    if [ `grep ^en_NL /etc/locale.gen|wc -l` -eq 0 ]; then
+        echo "en_NL.UTF-8 UTF-8" >> /etc/locale.gen
+    fi
+
+    # regenerate locales
+    locale-gen
+
+elif [ -x /usr/bin/localedef ]; then
+    /usr/bin/localedef -f UTF-8 -i en_NL en_NL.UTF-8
+else
+    echo "ERROR: Do not know how to register locale"
+    exit 1
+fi
 
 # list locale
 locale -a|grep en_NL


### PR DESCRIPTION
Wanted to get en_NL working on OpenSuse already for a long time, see #2, and recently got that working.

This patch makes the add.sh script work for OpenSuse (tested Tumbleweed) but it will default to the Debian/Ubuntu specific way of doing this using locale-gen

It furthermore adds error checking on running as root and the existence of /usr/share/i18n/