### PR TITLE
Add note about LC_CTYPE and add fix to `add.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,17 @@ https://sourceware.org/bugzilla/show_bug.cgi?id=14085
 Installation
 ------------
 
-Install the locale en\_NL with `./install.sh` or running the command from that
+Install the locale en\_NL with `./add.sh` or running the commands from that
 script manually.
+
+### Note: LC_CTYPE needs further intervention
+
+The LC\_CTYPE provided by this locale is identical to that provided by en_US.UTF-8.
+Nevertheless, further intervention is required to get everything to work smoothly
+([source](https://xyne.dev/projects/locale-en_xx/#usage)).
+There are two approaches:
+either explicitly set `LC_CTYPE=en_US.UTF-8` in `/etc/locale.conf`,
+or modify the Xlib database (which is what `add.sh` does, if this database exists).
 
 
 Validation

--- a/add.sh
+++ b/add.sh
@@ -15,6 +15,20 @@ if [ `grep ^en_NL /etc/locale.gen|wc -l` -eq 0 ]; then
     echo "en_NL.UTF-8 UTF-8" >> /etc/locale.gen
 fi
 
+# update Xlib database (see https://xyne.dev/projects/locale-en_xx/#usage)
+file=/usr/share/X11/locale/locale.dir
+if [ -f $file ] && [ `grep en_NL $file|wc -l` -eq 0 ]; then
+    echo >> $file
+    echo "en_US.UTF-8/XLC_LOCALE en_NL.UTF-8" >> $file
+    echo "en_US.UTF-8/XLC_LOCALE: en_NL.UTF-8" >> $file
+fi
+file=/usr/share/X11/locale/compose.dir
+if [ -f $file ] && [ `grep en_NL $file|wc -l` -eq 0 ]; then
+    echo >> $file
+    echo "en_US.UTF-8/Compose en_NL.UTF-8" >> $file
+    echo "en_US.UTF-8/Compose: en_NL.UTF-8" >> $file
+fi
+
 # regenerate locales
 locale-gen
 

--- a/add.sh
+++ b/add.sh
@@ -2,6 +2,11 @@
 
 # This will add the locale en_NL.
 
+if [ `id -u` -ne 0 ]; then
+    echo "ERROR: Please run this script as root"
+    exit 1
+fi
+
 # add locale
 cp -f en_NL /usr/share/i18n/locales/
 

--- a/en_NL
+++ b/en_NL
@@ -1,5 +1,5 @@
-escape_char /
 comment_char %
+escape_char /
 
 % This file is part of the GNU C Library and contains locale data.
 % The Free Software Foundation does not claim any copyright interest
@@ -17,8 +17,8 @@ contact     "Pander"
 email       "pander@users.sourceforge.net"
 language    "American English"
 territory   "Netherlands"
-revision    "3.0"
-date        "2020-05-27"
+revision    "3.1"
+date        "2023-04-26"
 
 category    "i18n:2012";LC_IDENTIFICATION
 category    "i18n:2012";LC_CTYPE
@@ -36,12 +36,12 @@ END LC_IDENTIFICATION
 
 LC_CTYPE
 % From en_US
-copy "i18n"
+copy "en_US"
 END LC_CTYPE
 
 LC_COLLATE
 % From en_US
-copy "iso14651_t1"
+copy "en_US"
 END LC_COLLATE
 
 LC_MONETARY
@@ -68,9 +68,7 @@ END LC_MONETARY
 
 LC_NUMERIC
 % From en_US
-decimal_point       "."
-thousands_sep       ","
-grouping            3;3
+copy "en_US"
 END LC_NUMERIC
 
 LC_TIME
@@ -99,10 +97,7 @@ END LC_TIME
 
 LC_MESSAGES
 % From en_US
-yesexpr             "^[+1yY]"
-noexpr              "^[-0nN]"
-yesstr              "yes"
-nostr               "no"
+copy "en_US"
 END LC_MESSAGES
 
 LC_PAPER


### PR DESCRIPTION
I noticed that my compose key wasn't working in some applications, like Telegram Desktop and the IntelliJ IDEs (IDEA, WebStorm, GoLand, ...). Additionally, tab titles were not displayed in [tabbed](https://tools.suckless.org/tabbed/). After [some](https://youtrack.jetbrains.com/issue/IDEA-59679/Cannot-type-dead-keys-in-Linux#focus=Comments-27-5724886.0-0) [research](https://git.suckless.org/tabbed/file/tabbed.c.html#l1358), I reached the conclusion that all of this was caused by the installation of this `en_NL` locale, and specifically, `LC_CTYPE` was causing trouble.

Apparently, this is a common problem with custom locale files, as I found [here](https://bbs.archlinux.org/viewtopic.php?pid=1295926#p1295926). I've copied the fixes listed by Xyne for his `en_XX` locale, which resolved all of the problems I mentioned above. 

