### PR TITLE
Fix install script path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://sourceware.org/bugzilla/show_bug.cgi?id=14085
 Installation
 ------------
 
-Install the locale en\_NL with `./install.sh` or running the command from that
+Install the locale en\_NL with `./add.sh` or running the command from that
 script manually.
 
 


### PR DESCRIPTION
The README currently points to `install.sh`, but that script no longer exists. I fixed it to point to `add.sh` instead.